### PR TITLE
feat: Add core changes/save functionality, combos service

### DIFF
--- a/proto/zmk/combos.options
+++ b/proto/zmk/combos.options
@@ -1,0 +1,1 @@
+zmk.combos.AddComboRequest.positions max_count:2

--- a/proto/zmk/combos.proto
+++ b/proto/zmk/combos.proto
@@ -1,0 +1,151 @@
+syntax = "proto3";
+
+package zmk.combos;
+
+import "keymap.proto";
+
+message Request {
+    oneof request_type {
+        bool get_combos = 1;
+        AddComboRequest add_combo = 2;
+        ComboIdRequest delete_combo = 3;
+        ComboPositionRequest set_combo_position_state = 4;
+        ComboIdRequest clear_combo_layers = 5;
+        ComboLayerRequest set_combo_layer_state = 6;
+        ComboSlowReleaseRequest set_combo_slow_release_state = 7;
+        ComboTimeoutRequest set_combo_timeout = 8;
+        ComboRequirePriorIdleRequest set_combo_require_prior_idle = 9;
+        ComboBindingRequest set_combo_binding = 10;
+    }
+}
+
+message Response {
+    oneof response_type {
+        GetCombosResponse get_combos = 1;
+        AddComboResponse add_combo = 2;
+        DeleteComboResponse delete_combo = 3;
+        ComboChangeResponse set_combo_position_state = 4;
+        ComboChangeResponse clear_combo_layers = 5;
+        ComboChangeResponse set_combo_layer_state = 6;
+        ComboChangeResponse set_combo_slow_release_state = 7;
+        ComboChangeResponse set_combo_timeout = 8;
+        ComboChangeResponse set_combo_require_prior_idle = 9;
+        ComboChangeResponse set_combo_binding = 10;
+    }
+}
+
+message Notification {
+    oneof notification_type {
+        bool unsaved_changes_status_changed = 1;
+    }
+}
+
+message Combo {
+  uint32 id = 1;
+  repeated uint32 positions = 2;
+  zmk.keymap.BehaviorBinding binding = 3;
+  uint32 timeout_ms = 4;
+  uint32 require_prior_idle_ms = 5;
+  uint32 layer_mask = 6;
+  bool slow_release = 7;
+}
+
+message Combos {
+  repeated Combo combos = 1;
+  uint32 free_combos = 2;
+}
+
+enum ComboErrorCode {
+  COMBO_ERROR_CODE_OK            = 0;
+  COMBO_ERROR_CODE_GENERIC       = 1;
+  COMBO_ERROR_CODE_NOT_SUPPORTED = 2;
+  COMBO_ERROR_CODE_NO_SPACE      = 3;
+  COMBO_ERROR_CODE_NOT_FOUND     = 4;
+  COMBO_ERROR_CODE_INVALID       = 5;
+}
+
+/*
+ * Adding combos will result in re-ordering, so clients should *not*
+ * depend on the returned order for consistent display, without first
+ * sorting on some field, preferrably the `id` field.
+ */
+message GetCombosResponse {
+  oneof result {
+    Combos ok = 1;
+    ComboErrorCode err = 2;
+  };
+}
+
+/*
+ * Combos have a minimum of 2 key positions to be usable,
+ * so when adding we expect exactly two key positions. Any
+ * additional key positions should be added after creation
+ * with `set_combo_position_state`
+ */
+message AddComboRequest {
+  repeated uint32 positions = 1;
+  zmk.keymap.BehaviorBinding binding = 2;
+  uint32 timeout_ms = 3;
+  uint32 require_prior_idle_ms = 4;
+  uint32 layer_mask = 5;
+  bool slow_release = 6;
+}
+
+message AddComboResponse {
+  oneof result {
+    uint32 ok_new_id = 1;
+    ComboErrorCode err = 2;
+  }
+}
+
+message ComboIdRequest {
+  uint32 id = 1;
+}
+
+message DeleteComboResponse {
+  oneof result {
+    bool ok = 1;
+    ComboErrorCode err = 2;
+  }
+}
+
+message ComboPositionRequest {
+  uint32 id = 1;
+  uint32 position = 2;
+  bool enabled = 3;
+}
+
+message ComboLayerRequest {
+  uint32 id = 1;
+  uint32 layer = 2;
+  bool enabled = 3;
+}
+
+message ComboTimeoutRequest {
+  uint32 id = 1;
+  uint32 timeout = 2;
+}
+
+message ComboRequirePriorIdleRequest {
+  uint32 id = 1;
+  uint32 require_prior_idle = 2;
+}
+
+
+message ComboSlowReleaseRequest {
+  uint32 id = 1;
+  bool enabled = 2;
+}
+
+message ComboBindingRequest {
+  uint32 id = 1;
+  zmk.keymap.BehaviorBinding binding = 2;
+}
+
+message ComboChangeResponse {
+  oneof result {
+    bool ok = 1;
+    ComboErrorCode err = 2;
+  }
+}
+

--- a/proto/zmk/core.proto
+++ b/proto/zmk/core.proto
@@ -13,6 +13,9 @@ message Request {
         bool get_lock_state = 2;
         bool lock = 3;
         bool reset_settings = 4;
+        bool check_unsaved_changes = 5;
+        bool save_changes = 6;
+        bool discard_changes = 7;
     }
 }
 
@@ -21,6 +24,9 @@ message Response {
         GetDeviceInfoResponse get_device_info = 1;
         LockState get_lock_state = 2;
         bool reset_settings = 4;
+        bool check_unsaved_changes = 5;
+        SaveChangesResponse save_changes = 6;
+        bool discard_changes = 7;
     }
 }
 
@@ -33,4 +39,18 @@ message Notification {
     oneof notification_type {
         LockState lock_state_changed = 1;
     }
+}
+
+message SaveChangesResponse {
+    oneof result {
+        bool ok = 1;
+        SaveChangesErrorCode err = 2;
+    }
+}
+
+enum SaveChangesErrorCode {
+    SAVE_CHANGES_ERR_OK = 0;
+    SAVE_CHANGES_ERR_GENERIC = 1;
+    SAVE_CHANGES_ERR_NOT_SUPPORTED = 2;
+    SAVE_CHANGES_ERR_NO_SPACE = 3;
 }

--- a/proto/zmk/studio.proto
+++ b/proto/zmk/studio.proto
@@ -7,6 +7,7 @@ import "meta.proto";
 import "core.proto";
 import "behaviors.proto";
 import "keymap.proto";
+import "combos.proto";
 
 message Request {
     uint32 request_id = 1;
@@ -15,6 +16,7 @@ message Request {
         zmk.core.Request core = 3;
         zmk.behaviors.Request behaviors = 4;
         zmk.keymap.Request keymap = 5;
+        zmk.combos.Request combos = 6;
     }
 }
 
@@ -32,6 +34,7 @@ message RequestResponse {
         zmk.core.Response core = 3;
         zmk.behaviors.Response behaviors = 4;
         zmk.keymap.Response keymap = 5;
+        zmk.combos.Response combos = 6;
     }
 }
 
@@ -39,5 +42,6 @@ message Notification {
     oneof subsystem {
         zmk.core.Notification core = 2;
         zmk.keymap.Notification keymap = 5;
+        zmk.combos.Notification combos = 6;
     }
 }


### PR DESCRIPTION
Add functionality to save/restore/discard changes to the core service, instead of isolated in the keymap subsystem. Also add a new combos subsystem.